### PR TITLE
メソッド名のみ変更

### DIFF
--- a/src/main/java/org/example/domain/battleship/BattleShip.java
+++ b/src/main/java/org/example/domain/battleship/BattleShip.java
@@ -37,7 +37,7 @@ public class BattleShip {
         try {
             showField();
             String c = input(scanner, ship);
-            var coordinates = extractCoordinates(c);
+            var coordinates = extractValidCoordinates(c);
 
 
 
@@ -142,7 +142,7 @@ public class BattleShip {
 
 
 
-     Map<String, Map<String, Integer>> extractCoordinates(String inputCoordinatesFromUser) throws InvalidInputFormatException {
+     Map<String, Map<String, Integer>> extractValidCoordinates(String inputCoordinatesFromUser) throws InvalidInputFormatException {
 
         String[] c = split(inputCoordinatesFromUser);
 

--- a/src/test/java/org/example/domain/battleship/BattleShipTest.java
+++ b/src/test/java/org/example/domain/battleship/BattleShipTest.java
@@ -128,7 +128,7 @@ public class BattleShipTest {
         expected.get("end").put("row", 0);
         expected.get("end").put("column", 4);
 
-        Map<String, Map<String, Integer>> actual = battleShip.extractCoordinates("A1 A5");
+        Map<String, Map<String, Integer>> actual = battleShip.extractValidCoordinates("A1 A5");
 
         assertEquals(expected.get("start").get("row"), actual.get("start").get("row"));
         assertEquals(expected.get("start").get("column"), actual.get("start").get("column"));
@@ -181,13 +181,13 @@ public class BattleShipTest {
     @Test
     @DisplayName("船を斜めに置いたらInvalidInputFormatExceptionを投げる")
     void whenPutShipOnCross_ThrowInvalidInputFormatException()  {
-        assertThrows(InvalidInputFormatException.class, () -> battleShip.extractCoordinates("A1 B5"));
+        assertThrows(InvalidInputFormatException.class, () -> battleShip.extractValidCoordinates("A1 B5"));
     }
 
     @Test
     @DisplayName("船がフィールドからはみ出たらInvalidInputFormatExceptionを投げる")
     void whenShipFieldWithOut_ThrowInvalidInputFormatException() {
-        assertThrows(InvalidInputFormatException.class, () -> battleShip.extractCoordinates("A7 A11"));
+        assertThrows(InvalidInputFormatException.class, () -> battleShip.extractValidCoordinates("A7 A11"));
     }
 
     @Test


### PR DESCRIPTION
不正な値を弾く処理と座標を抽出する処理を分けようと思ったが、分けることができなそうだったので、メソッド名の変更のみにとどめた